### PR TITLE
Added a note to the README file about an alternative widget that can be used with this service

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ Entity Name | Description
 climate.ca350_fan | Expose Temperature Control & Fan Control
 
 ## HA Lovelace Widget:
-An read only Lovelace Widget - depending on the MQTT AD enities: https://github.com/TimWeyand/lovelace-comfoair
+The following Lovelace widgets depend on the MQTT AD enities and can be used with this service:
+
+* https://github.com/TimWeyand/lovelace-comfoair
+* https://github.com/mweimerskirch/lovelace-hacomfoairmqtt
 
 ## TODO:
 - [ ] Create installation script for automatic installation of the script


### PR DESCRIPTION
I created an alternative widget because I wanted to have something lighter. I created it from scratch, because there was no source code available for the other widget (only a compiled JS file).