### PR TITLE
Default no fan entity autodiscovery and fixing mqtt topic deletion

### DIFF
--- a/src/ca350
+++ b/src/ca350
@@ -43,7 +43,7 @@ MQTTKeepalive = int(config['MQTT']['MQTTKeepalive']) # MQTT broker - keepalive
 MQTTUser = config['MQTT']['MQTTUser']                # MQTT broker - user - default: 0 (disabled/no authentication)
 MQTTPassword = config['MQTT']['MQTTPassword']        # MQTT broker - password - default: 0 (disabled/no authentication)
 
-HAEnableAutoDiscoveryFan = config['HA']['HAEnableAutoDiscoveryFan'] == 'True'         # Home Assistant send auto discovery for fan
+HAEnableAutoDiscoveryFan = config['HA']['HAEnableAutoDiscoveryFan'] == 'False'         # Home Assistant send auto discovery for fan. Fan not needed as all features available in climate entity
 HAEnableAutoDiscoverySensors = config['HA']['HAEnableAutoDiscoverySensors'] == 'True' # Home Assistant send auto discovery for temperatures
 #Todo: HA AD Climate is work in progress
 HAEnableAutoDiscoveryClimate = config['HA']['HAEnableAutoDiscoveryClimate'] == 'True' # Work in Progress: Home Assistant send auto discovery for climate
@@ -682,7 +682,7 @@ def on_connect(client, userdata, flags, rc):
         info_msg('Home Assistant MQTT Autodiscovery Topic Set: homeassistant/fan/ca350_fan/config')
         publish_message('{"name":"ca350_fan","avty_t":"comfoair/status","pl_avail":"online","pl_not_avail":"offline","stat_t": "comfoair/on/state","cmd_t": "comfoair/on/set","spd_stat_t": "comfoair/speed/state","spd_cmd_t": "comfoair/speed/set","pl_on": "20","pl_off": "10","pl_lo_spd": "20","pl_med_spd": "30","pl_hi_spd": "40","spds": ["off","low","medium","high"]}',"homeassistant/fan/ca350_fan/config")
     else:
-        delete_message("homeassistant/climate/ca350_fan/config")
+        delete_message("homeassistant/fan/ca350_fan/config")
     if HAEnableAutoDiscoverySensors is True :
         info_msg('Home Assistant MQTT Autodiscovery Topic Set: homeassistant/sensor/ca350_[nametemp]/config')
         publish_message('{"name":"ca350_outsidetemp","avty_t":"comfoair/status","pl_avail":"online","pl_not_avail":"offline","device_class":"temperature","state_topic":"comfoair/outsidetemp","unit_of_measurement":"°C"}',"homeassistant/sensor/ca350_outsidetemp/config")

--- a/src/config.ini.dist
+++ b/src/config.ini.dist
@@ -23,10 +23,10 @@ MQTTPassword=
 
 [HA]
 # Home Assistant send auto discovery for fan
-HAEnableAutoDiscoveryFan=True
+HAEnableAutoDiscoveryFan=False
 # Home Assistant send auto discovery for temperatures
 HAEnableAutoDiscoverySensors=True
 #Todo: HA AD Climate is work in progress
 # Work in Progress: Home Assistant send auto discovery for climate
-HAEnableAutoDiscoveryClimate=False
+HAEnableAutoDiscoveryClimate=True
 


### PR DESCRIPTION
Fan entity no longer enabled by default
Fixing auto discovery MQTT topic deletion for fan entity