### PR TITLE
Update ca350.py

### DIFF
--- a/src/ca350.py
+++ b/src/ca350.py
@@ -847,6 +847,7 @@ def send_autodiscover(name, entity_id, entity_type, state_topic = None, device_c
         
     if unit_of_measurement:
         discovery_message["unit_of_measurement"] = unit_of_measurement
+        discovery_message["state_class"] = "measurement"
 
     if device_class:
         discovery_message["device_class"] = device_class


### PR DESCRIPTION
When you cann internal Home Assistant API "recorder/statistics_during_period" CA350 temp sensors missing state_class property don't return correct data. This fix and make ca350 temperature sensors standard.